### PR TITLE
로그인 기능 구현

### DIFF
--- a/src/main/java/com/wanted/preonboarding/global/NotValidException.java
+++ b/src/main/java/com/wanted/preonboarding/global/NotValidException.java
@@ -1,0 +1,11 @@
+package com.wanted.preonboarding.global;
+
+public class NotValidException extends RuntimeException {
+    private final String code;
+    private final String message;
+
+    public NotValidException(final String code, final String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/wanted/preonboarding/global/security/CustomUserDetailService.java
+++ b/src/main/java/com/wanted/preonboarding/global/security/CustomUserDetailService.java
@@ -27,7 +27,7 @@ public class CustomUserDetailService implements UserDetailsService {
     private UserDetails createUserDetails(Member member) {
         return User.builder()
                 .username(member.getEmail())
-                .password(passwordEncoder.encode(member.getPassword()))
+                .password(member.getPassword())
                 .roles(member.getRole().toString())
                 .build();
     }

--- a/src/main/java/com/wanted/preonboarding/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/wanted/preonboarding/global/security/JwtTokenProvider.java
@@ -59,7 +59,7 @@ public class JwtTokenProvider {
                 .compact();
 
         return TokenDto.builder()
-                .role(Role.ROLE_MEMBER)
+                .role(Role.MEMBER)
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();

--- a/src/main/java/com/wanted/preonboarding/global/security/SecurityConfig.java
+++ b/src/main/java/com/wanted/preonboarding/global/security/SecurityConfig.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -33,6 +33,6 @@ public class SecurityConfig {
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/wanted/preonboarding/member/api/MemberApi.java
+++ b/src/main/java/com/wanted/preonboarding/member/api/MemberApi.java
@@ -1,6 +1,8 @@
 package com.wanted.preonboarding.member.api;
 
+import com.wanted.preonboarding.member.dto.request.LoginRequest;
 import com.wanted.preonboarding.member.dto.request.SignUpRequest;
+import com.wanted.preonboarding.member.dto.response.LoginResponse;
 import com.wanted.preonboarding.member.dto.response.SignUpResponse;
 import com.wanted.preonboarding.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -18,8 +20,13 @@ public class MemberApi {
 
     private final MemberService memberService;
 
-    @PostMapping
+    @PostMapping("/signup")
     public SignUpResponse signUp(final @RequestBody @Valid SignUpRequest signUpRequest) {
         return memberService.save(signUpRequest);
+    }
+
+    @PostMapping("/login")
+    public LoginResponse login(final @RequestBody @Valid LoginRequest loginRequest) {
+        return memberService.login(loginRequest);
     }
 }

--- a/src/main/java/com/wanted/preonboarding/member/domain/Member.java
+++ b/src/main/java/com/wanted/preonboarding/member/domain/Member.java
@@ -36,6 +36,6 @@ public class Member {
     public Member(String email, String password) {
         this.email = email;
         this.password = password;
-        this.role = Role.ROLE_MEMBER;
+        this.role = Role.MEMBER;
     }
 }

--- a/src/main/java/com/wanted/preonboarding/member/domain/Role.java
+++ b/src/main/java/com/wanted/preonboarding/member/domain/Role.java
@@ -1,6 +1,6 @@
 package com.wanted.preonboarding.member.domain;
 
 public enum Role {
-    ROLE_ADMIN,
-    ROLE_MEMBER
+    ADMIN,
+    MEMBER
 }

--- a/src/main/java/com/wanted/preonboarding/member/dto/request/LoginRequest.java
+++ b/src/main/java/com/wanted/preonboarding/member/dto/request/LoginRequest.java
@@ -1,0 +1,20 @@
+package com.wanted.preonboarding.member.dto.request;
+
+import lombok.Getter;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Size;
+
+@Getter
+public class LoginRequest {
+    @Email
+    private final String email;
+
+    @Size(min = 8)
+    private final String password;
+
+    public LoginRequest(final String email, final String password) {
+        this.email = email;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/wanted/preonboarding/member/dto/response/LoginResponse.java
+++ b/src/main/java/com/wanted/preonboarding/member/dto/response/LoginResponse.java
@@ -1,0 +1,15 @@
+package com.wanted.preonboarding.member.dto.response;
+
+import com.wanted.preonboarding.global.security.TokenDto;
+import lombok.Getter;
+
+@Getter
+public class LoginResponse {
+    private final String accessToken;
+    private final String refreshToken;
+
+    public LoginResponse(final TokenDto tokenDto) {
+        this.accessToken = tokenDto.getAccessToken();
+        this.refreshToken = tokenDto.getRefreshToken();
+    }
+}

--- a/src/main/java/com/wanted/preonboarding/member/exception/PasswordNotValidException.java
+++ b/src/main/java/com/wanted/preonboarding/member/exception/PasswordNotValidException.java
@@ -1,0 +1,12 @@
+package com.wanted.preonboarding.member.exception;
+
+import com.wanted.preonboarding.global.NotValidException;
+
+public class PasswordNotValidException extends NotValidException {
+    private static final String ERROR_CODE = "INVALID_PASSWORD_ERROR";
+    private static final String ERROR_MESSAGE = "패스워드가 일치하지 않습니다.";
+
+    public PasswordNotValidException(String email) {
+        super(ERROR_CODE, String.format("%s : %s", ERROR_MESSAGE, email));
+    }
+}

--- a/src/main/java/com/wanted/preonboarding/member/service/MemberService.java
+++ b/src/main/java/com/wanted/preonboarding/member/service/MemberService.java
@@ -7,6 +7,7 @@ import com.wanted.preonboarding.member.exception.MemberDuplicatedException;
 import com.wanted.preonboarding.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -15,11 +16,13 @@ import org.springframework.stereotype.Service;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public SignUpResponse save(final SignUpRequest signUpRequest) {
         validateDuplicatedMember(signUpRequest.getEmail());
 
-        Member member = new Member(signUpRequest.getEmail(), signUpRequest.getPassword());
+        String encodedPassword = passwordEncoder.encode(signUpRequest.getPassword());
+        Member member = new Member(signUpRequest.getEmail(), encodedPassword);
 
         memberRepository.save(member);
         log.info("Member saved '{}'", member.getEmail());

--- a/src/main/java/com/wanted/preonboarding/member/service/MemberService.java
+++ b/src/main/java/com/wanted/preonboarding/member/service/MemberService.java
@@ -1,12 +1,19 @@
 package com.wanted.preonboarding.member.service;
 
+import com.wanted.preonboarding.global.security.JwtTokenProvider;
+import com.wanted.preonboarding.global.security.TokenDto;
 import com.wanted.preonboarding.member.domain.Member;
+import com.wanted.preonboarding.member.dto.request.LoginRequest;
 import com.wanted.preonboarding.member.dto.request.SignUpRequest;
+import com.wanted.preonboarding.member.dto.response.LoginResponse;
 import com.wanted.preonboarding.member.dto.response.SignUpResponse;
 import com.wanted.preonboarding.member.exception.MemberDuplicatedException;
 import com.wanted.preonboarding.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -16,7 +23,9 @@ import org.springframework.stereotype.Service;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
 
     public SignUpResponse save(final SignUpRequest signUpRequest) {
         validateDuplicatedMember(signUpRequest.getEmail());
@@ -34,5 +43,19 @@ public class MemberService {
         if (memberRepository.existsByEmail(email)) {
             throw new MemberDuplicatedException(email);
         }
+    }
+
+    public LoginResponse login(final LoginRequest loginRequest) {
+        // 1. Login ID/PW 기반으로 Authentication 객체 생성
+        // 이 때 authentication 는 인증 여부를 확인하는 authenticated 값이 false
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(loginRequest.getEmail(), loginRequest.getPassword());
+
+        // 2. 실제 검증 (사용자 비밀번호 체크)이 이루어지는 부분
+        // authenticate 메서드가 실행될 때 CustomUserDetailsService 에서 만든 loadUserByUsername 가 실행
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+        // 3. Authentication 객체를 통해 Principal 얻기
+        TokenDto tokenDto = jwtTokenProvider.generateToken(authentication);
+
+        return new LoginResponse(tokenDto);
     }
 }


### PR DESCRIPTION
# 개요
로그인 기능을 구현했습니다.

# 작업내역
## 패스워드 암호화 저장
패스워드를 암호화하여 저장하도록 구현했습니다.
현재 BCryptPasswordEncoder 단방향 암호화 알고리즘을 사용 중 입니다.

## Member Role 수정
Member의 Role을 수정했습니다. Security 자체적으로 prefix로 'ROLE_'을 붙이기 때문에 enum 클래스에선 'MEMBER, ADMIN'으로 작성했습니다.

## 로그인 기능 구현
로그인 기능을 구현하고 로그인이 성공하면 AccessToken과 RefreshToken을 반환하도록 구현했습니다. 
